### PR TITLE
Enable overriding and extending list value

### DIFF
--- a/kuku/types.py
+++ b/kuku/types.py
@@ -8,9 +8,3 @@ Templates = Dict[str, Callable]
 
 # template file path -> List of K8S objects
 Rendering = Dict[str, List[Any]]
-
-
-class IgnoredListItem:
-    """Placeholder list item to be ignored for deep merges of lists"""
-
-    ...

--- a/kuku/values.py
+++ b/kuku/values.py
@@ -1,9 +1,9 @@
-from typing import List
+from typing import List, Mapping
 
 import yaml
 
 from kuku.types import Context
-from kuku.utils.dict import unroll_key, merge_deep
+from kuku.utils.dict import unroll_key, merge_deep, IGNORED_LIST_ITEM
 
 
 def resolve(values: List[str], value_files: List[str]) -> Context:
@@ -33,4 +33,18 @@ def resolve(values: List[str], value_files: List[str]) -> Context:
 
             context = merge_deep(unroll_key(key, value), context)
 
+    check_placeholder(context)
     return context
+
+
+def check_placeholder(context: dict) -> None:
+    """Assert that all the placeholders have been replaced."""
+    for key, value in context.items():
+        if isinstance(value, list):
+            # Check if we have any placeholder left
+            if any([v for v in value if v == IGNORED_LIST_ITEM]):
+                raise ValueError(
+                    "some item in the list '%s' has not been given a value." % key
+                )
+        elif isinstance(value, dict):
+            check_placeholder(value)


### PR DESCRIPTION
With this commit, it's now possible to set a value to a specific item in
a list with the CLI: "kuku render ./templates --set a.0=foo"

Code is a bit tricky, prepare a pen if you want to proof-read it.
Otherwise, reading the unit tests should give a good confidence level.